### PR TITLE
Erros ortográficos e um probleminha no exemplo

### DIFF
--- a/python/unidade-3.ipynb
+++ b/python/unidade-3.ipynb
@@ -192,7 +192,7 @@
    "metadata": {},
    "source": [
     "### Exercício 3: Palíndromos 👑\n",
-    "Segundo a [Oxford Languages](https://languages.oup.com/google-dictionary-pt/), *plaíndromos* são testos que se pode ler, indiferentemente, da esquerda para a direita ou vice-versa. Por exemplo: \"arara\", \"asa\", \"mirim\"... E também as frases: \"A cara rajada da jararaca\", \"Socorram-me, subi no ônivus em Marrocos\"...Perceba que, em frases, deve-se ignorar a pontuação, acentuação, espaços e maiúsculas/minúsculas.\n",
+    "Segundo a [Oxford Languages](https://languages.oup.com/google-dictionary-pt/), *plaíndromos* são textos que se pode ler, indiferentemente, da esquerda para a direita ou vice-versa. Por exemplo: \"arara\", \"asa\", \"mirim\"... E também as frases: \"A cara rajada da jararaca\", \"Socorram-me, subi no ônibus em Marrocos\"...Perceba que, em frases, deve-se ignorar a pontuação, acentuação, espaços e maiúsculas/minúsculas.\n",
     "\n",
     "Implemente a função *verifica_palindromo* que recebe como parâmetro uma string (texto ou única palavra) e retorna *true* caso o parâmetro seja um palíndromo ou *false*, caso contrário. \n",
     "\n",

--- a/python/unidade-3.ipynb
+++ b/python/unidade-3.ipynb
@@ -143,7 +143,7 @@
    "source": [
     "# Faça os testes \n",
     "resultado_1 = elimina_caracteres('correndo contra o tempo', 'coe')\n",
-    "resultado_2 = elimina_caracteres('trigo para tigres tristes', 'ie') #saída: trg para tgrs trsts\n",
+    "resultado_2 = elimina_caracteres('trigo para tigres tristes', 'ieo') #saída: trg para tgrs trsts\n",
     "\n",
     "#lembre-se de imprimir os resultados\n"
    ]
@@ -154,7 +154,7 @@
    "source": [
     "- **substitua_caracteres**: (3 parâmetros) Dado um texto, uma string de procura e uma string de reposição, sendo que a string de procura e reposição são de mesmo tamanho. Substitua no texto o caractere na posição i da string de procura pelo caractere na mesma posição i na string de reposição. O texto, os caracteres a serem procurados no texto e os caracteres a serem colocados no lugar serão passados como parâmetro.\n",
     "    \n",
-    "Exemplo:  `substitua_caracteres('o sapo não lava o pé', 'aoe', 'iiu')` devem resultar na string `'i sipi nii livi i pu'`.\n",
+    "Exemplo:  `substitua_caracteres('o sapo nao lava o pe', 'aoe', 'iiu')` devem resultar na string `'i sipi nii livi i pu'`.\n",
     "    \n",
     "DICA: Será necessario usar o *.replace* uma vez para cada caractere especificado (ou seja, dentro de um laço)."
    ]
@@ -183,7 +183,7 @@
     "#testes! Faça mais para verificar todos os casos.\n",
     "# Lembre-se de imprimir o resultado.\n",
     "\n",
-    "resultado_1 = substitua_caracteres('o sapo não lava o pé', 'aoe', 'iiu')\n",
+    "resultado_1 = substitua_caracteres('o sapo nao lava o pe', 'aoe', 'iiu')\n",
     "resultado_2 = substitua_caracteres('ana comprou uma ariranha', 'aoi', 'uee') #saida: unu cempreu umu urerunhu"
    ]
   },


### PR DESCRIPTION
Um dos exemplos do exercício 2 da unidade 3 utiliza o exemplo:
```python
resultado_2 = elimina_caracteres('trigo para tigres tristes', 'ie') #saída: trg para tgrs trsts\n"
```
Minha sugestão é incluir a letra 'o' nas letras a serem removidas para que a saída esperada seja realmente encontrada.

Outra sugestão é a remoção das acentuações no seguinte exemplo do exercício 2 da unidade 3:

```python
substitua_caracteres('o sapo não lava o pé', 'aoe', 'iiu')
```

Nesse caso, como `a` é diferente de `ã` e `e` é diferente de `é`, então a string esperada como resposta é:
```
i sipi nãi livi i pé
```
Para não ter que mudar o enunciado, pode-se remover os acentos da frase para que a saída realmente esperada seja encontrada. Caso o objetivo fosse lidar com os acentos, seria interessante explicitar no enunciado.

O resto são alguns erros de ortografia que podem ser encontrados nos commit's desse PR.

obs: Todas as minhas sugestões são baseadas no escopo das questões 2 e 3 da unidade 3 que foram passadas na aula de RI. Se alguma informação do que foi sugerida foi explicada em outra unidade ou em outra questão, desculpe-me por não ter notado.
